### PR TITLE
Add 'direction' to Entity

### DIFF
--- a/include/Entities/Entity.hpp
+++ b/include/Entities/Entity.hpp
@@ -37,6 +37,10 @@ public:
   // Set the current velocity
   void setVel(sf::Vector2f vel);
 
+  // Get the direction angle (in degrees, 0 is directly right, increases going clockwise)
+  // Entity direction is determined by the most recent non-zero velocity.
+  float getDirection();
+
   void setSprite(sf::Sprite sprite);
 
   // Attach a Box2D shape to this object
@@ -58,6 +62,8 @@ public:
 protected:
   sf::Vector2f pos_;
   sf::Vector2f vel_;
+  float dir_;
+
   sf::Sprite sprite_;
 
   // Box2D shape object used for collision calculations  

--- a/include/Entities/Laser.hpp
+++ b/include/Entities/Laser.hpp
@@ -10,10 +10,9 @@
 class Laser : public Entity{
 
 protected:
-    sf::Vector2f pos_;
     bool hacked_;
     sf::Sprite sprite_;
-    float dir_;
+
     float startRotate_;
     float endRotate_;
     float shootTime_;
@@ -22,18 +21,15 @@ protected:
 public:
     Laser();
 
+    // Set this laser's angle, in degrees (0 is right, increases clockwise)
+    void setDirection(float angle);
 
-    //return direction: 0,1,2,3 -> NORTH,EAST,SOUTH,WEST
-    int getDirection();
-
-
+    // Set the bounding angles for this laser's rotation
     void setRotate(float startRotate, float endRotate);
 
     void setShootTime(float shootTime);
 
     void setStopTime(float stopTime);
-
-    void setDirection(float dir);
 
     //rotate the device
     void rotate(float angle);

--- a/include/VecUtil.hpp
+++ b/include/VecUtil.hpp
@@ -21,16 +21,27 @@ float clamp(float val, float cmin, float cmax);
 // on elements of vector val.
 sf::Vector2f clampVec2(sf::Vector2f val, sf::Vector2f min, sf::Vector2f max);
 
+// Returns true if any vector component is not zero; false otherwise.
+// If this returns true, value returned by length must be nonzero, and
+// vecutil::angle(v) must not fail.
+bool nonZero(sf::Vector2f v);
+
 // Returns a dot product of two vectors.
 float dotProd(sf::Vector2f, sf::Vector2f);
 
 // Returns the magnitude of the vector.
 float length(sf::Vector2f);
 
-// Returns the polar angle of this vector's direction.
+// Returns the polar angle of this vector's direction, in radians.
 // Can return nan or other error-y values for vectors whose angle is uncertain,
 // such as zero.
 float angle(sf::Vector2f);
+
+// Converts angle in radians to angle in degrees.
+float radToDeg(float rad);
+
+// Returns an approximate value for pi.
+float pi();
 
 // Returns a normalized (1-length) vector in the direction of the provided,
 // or a zero-vector if provided with a zero-vector.

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1,6 +1,6 @@
 #include "Entities/Entity.hpp"
 
-#include "Logic.hpp"
+#include "VecUtil.hpp"
   
 Entity::Entity(){};
 
@@ -40,6 +40,13 @@ sf::Vector2f Entity::getVel(){
 // Set the current velocity
 void Entity::setVel(sf::Vector2f vel){
 	vel_ = vel;
+    if ( vecutil::nonZero(vel) != 0 ) {
+        dir_ = vecutil::radToDeg(vecutil::angle(vel));
+    }
+}
+
+float Entity::getDirection() {
+    return dir_;
 }
 
 void Entity::setSprite(sf::Sprite sprite){

--- a/src/Entities/Laser.cpp
+++ b/src/Entities/Laser.cpp
@@ -4,7 +4,6 @@
 
 #include "Entities/Laser.hpp"
 
-#include "Logic.hpp"
 const float Laser::COLLISION_SIZE = 32.0f;
 Laser::Laser(){
     sf::Texture texture;
@@ -24,6 +23,10 @@ Laser::Laser(){
     hacked_=false;
 }
 
+void Laser::setDirection(float angle) {
+    dir_ = angle;
+}
+
 void Laser::setRotate(float startRotate, float endRotate){
     startRotate_=startRotate;
     endRotate_=endRotate;
@@ -35,15 +38,6 @@ void Laser::setShootTime(float shootTime){
 
 void Laser::setStopTime(float stopTime){
     stopTime_=stopTime;
-}
-
-
-void Laser::setDirection(float dir){
-    dir_=dir;
-}
-
-int Laser::getDirection(){
-    return dir_;
 }
 
 void Laser::rotate(float angle){

--- a/src/Screens/GameScreen.cpp
+++ b/src/Screens/GameScreen.cpp
@@ -101,7 +101,9 @@ void GameScreen::renderTiles(sf::RenderWindow *window) {
 }
 
 void GameScreen::renderEntities(sf::RenderWindow *window) {
-	//logic_->getCharacter().render(window);
+	// debug message to test that direction private variable works
+    std::cout << "GameScreen.cpp: character dir: " << logic_->getCharacter().getDirection() << std::endl;
+
     for (auto& pair : logic_->getEntities()) {
         pair.second->render(window);
 

--- a/src/VecUtil.cpp
+++ b/src/VecUtil.cpp
@@ -21,9 +21,17 @@ float vecutil::dotProd(sf::Vector2f a, sf::Vector2f b) {
     return a.x * b.x + a.y * b.y;
 }
 
+bool vecutil::nonZero(sf::Vector2f v) {
+    return v.x != 0 || v.y != 0;
+}
+
 float vecutil::length(sf::Vector2f vec) { return sqrt(dotProd(vec, vec)); }
 
 float vecutil::angle(sf::Vector2f vec) { return atan2(vec.y, vec.x); }
+
+float vecutil::radToDeg(float rad) { return rad * 180.0f / pi(); }
+
+float vecutil::pi() { return 4 * atan(1); }
 
 sf::Vector2f vecutil::normalize(sf::Vector2f vec) {
     if (vec.x == 0 && vec.y == 0) {


### PR DESCRIPTION
Should be useful for drawing sprites with an appropriately rotated
orientation

- Direction set during setVel, determined by the last non-zero velocity
  of the entity
- Can be overwritten (particularly in the case of Laser?)
- No 'set' function for Direction in Entity, though one could be added
  such as in Laser
- May behave oddly upon collisions due to collisions shoving the
  character out of walls using velocity

- also adds more math functions to VecUtil for dealing with angles